### PR TITLE
Create favorite

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ var indexRouter = require('./routes/index');
 var usersRouter = require('./routes/api/v1/users');
 var sessionsRouter = require('./routes/api/v1/sessions');
 var forecastsRouter = require('./routes/api/v1/forecasts');
+var favoritesRouter = require('./routes/api/v1/favorites');
 
 var app = express();
 
@@ -27,6 +28,7 @@ app.use('/', indexRouter);
 app.use('/api/v1/users', usersRouter);
 app.use('/api/v1/sessions', sessionsRouter);
 app.use('/api/v1/forecast', forecastsRouter);
+app.use('/api/v1/favorites', favoritesRouter);
 
 
 module.exports = app;

--- a/migrations/20190701044109-create-favorite.js
+++ b/migrations/20190701044109-create-favorite.js
@@ -1,0 +1,27 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('Favorites', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      location: {
+        type: Sequelize.STRING
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('Favorites');
+  }
+};

--- a/migrations/20190701044452-addUserIdToFavorite.js
+++ b/migrations/20190701044452-addUserIdToFavorite.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn(
+         'Favorites',//table we are adding the column too
+         'UserId', //the foreign key that we are adding
+         {
+          type: Sequelize.INTEGER,
+          references: {
+            model: 'Users', // name of Target model
+            key: 'id', // key in Target model that we're referencing
+          },
+          onUpdate: 'CASCADE',
+          onDelete: 'SET NULL',
+        }
+       )
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn(
+      'Favorites',
+      'UserId'
+    )
+  }
+};

--- a/models/favorite.js
+++ b/models/favorite.js
@@ -4,7 +4,7 @@ module.exports = (sequelize, DataTypes) => {
     location: DataTypes.STRING
   }, {});
   Favorite.associate = function(models) {
-    // associations can be defined here
+    Favorite.belongsTo(models.User)
   };
   return Favorite;
 };

--- a/models/favorite.js
+++ b/models/favorite.js
@@ -1,0 +1,10 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const Favorite = sequelize.define('Favorite', {
+    location: DataTypes.STRING
+  }, {});
+  Favorite.associate = function(models) {
+    // associations can be defined here
+  };
+  return Favorite;
+};

--- a/models/user.js
+++ b/models/user.js
@@ -6,7 +6,7 @@ module.exports = (sequelize, DataTypes) => {
     api_key: DataTypes.STRING
   }, {});
   User.associate = function(models) {
-    // associations can be defined here
+    User.hasMany(models.Favorite)
   };
   return User;
 };

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -1,0 +1,7 @@
+var express = require('express');
+var router = express.Router();
+var User = require('../../../models').User
+
+router.post('/', async function(req, res, next) {
+  
+})

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -1,7 +1,27 @@
 var express = require('express');
 var router = express.Router();
 var User = require('../../../models').User
+var Favorite = require('../../../models').Favorite
+
+var pry = require('pryjs')
 
 router.post('/', async function(req, res, next) {
-  
+  let user = await User.findOne({
+    where: {
+      api_key: req.body.api_key
+    }
+  })
+  let rawLocation = req.body.location
+  let location = rawLocation.replace(' ', '').toLowerCase()
+  if(user != null) {
+    let favorite = await Favorite.create({
+      location: location,
+      userId: user.id
+    })
+    res.status(200).send({ message: `${rawLocation} has been added to your favorites`})
+  } else {
+    res.status(401).send({ message: `Incorrect API key`})
+  }
 })
+
+module.exports = router;


### PR DESCRIPTION
Creates a POST favorites route where a user can pass a body of a city which gets downcased, saved to the DB, and associated to that user. No new services or serializers were required. A favorites model was express generated and associated table was added to the database.